### PR TITLE
fix: Added a specific dimension to logo and web-font display swap

### DIFF
--- a/public/app.css
+++ b/public/app.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css?family=Roboto+Mono:100,300,400');
+@import url('https://fonts.googleapis.com/css?family=Roboto+Mono:100,300,400&display=swap');
 @import url('twemoji-awesome.css');
 .twa-heart {
   background-image: url("https://twemoji.maxcdn.com/2/svg/2764.svg"); }

--- a/public/index.html
+++ b/public/index.html
@@ -28,7 +28,7 @@
   <meta name="twitter:description" content="" />
   <meta name="twitter:image" content="img/logo.png" />
 
-  <link rel="icon" href="img/logo.png" alt="Image Search App Logo" type="image/png" sizes="512X512">
+  <link rel="icon" href="img/logo.png" alt="Image Search App Logo" type="image/png" width="300" height="300">
 
   <link rel="manifest" href="./manifest.json" />
   <meta name="theme-color" content="#78c2ad" />


### PR DESCRIPTION
This PR adds a specific dimension to the logo of the homepage; also a display font swap to avoid text being invisible during web-font load.