### PR TITLE
fix: Solved the issue with the image alt text

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -28,7 +28,7 @@
   <meta name="twitter:description" content="" />
   <meta name="twitter:image" content="img/logo.png" />
 
-  <link rel="icon" href="img/logo.png" alt="Image Search App Logo" type="image/png" sizes="512X512">
+  <link rel="icon" href="img/logo.png" alt="Image Search App Logo_" type="image/png" sizes="512X512">
 
   <link rel="manifest" href="./manifest.json" />
   <meta name="theme-color" content="#78c2ad" />


### PR DESCRIPTION
This ###Pull Request solves the issue of no image `alt` text in the webpage's logo image.